### PR TITLE
fix(INC-5312): adding placeholder when image is empty

### DIFF
--- a/frontend/src/components/Item/Comment.js
+++ b/frontend/src/components/Item/Comment.js
@@ -14,7 +14,7 @@ const Comment = (props) => {
           <div className="d-flex flex-row align-items-center pt-2">
             <Link to={`/@${comment.seller.username}`} className="user-pic mr-2">
               <img
-                src={comment.seller.image}
+                src={comment.seller.image || "/placeholder.png"}
                 className="user-pic rounded-circle"
                 alt={comment.seller.username}
               />

--- a/frontend/src/components/Item/CommentInput.js
+++ b/frontend/src/components/Item/CommentInput.js
@@ -43,7 +43,7 @@ class CommentInput extends React.Component {
         </div>
         <div className="card-footer">
           <img
-            src={this.props.currentUser.image}
+            src={this.props.currentUser.image || "/placeholder.png"}
             className="user-pic mr-2"
             alt={this.props.currentUser.username}
           />

--- a/frontend/src/components/Item/ItemMeta.js
+++ b/frontend/src/components/Item/ItemMeta.js
@@ -8,7 +8,7 @@ const ItemMeta = (props) => {
     <div className="d-flex flex-row align-items-center pt-2">
       <Link to={`/@${item.seller.username}`}>
         <img
-          src={item.seller.image}
+          src={item.seller.image || "/placeholder.png"}
           alt={item.seller.username}
           className="user-pic mr-2"
         />

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />
@@ -48,7 +48,7 @@ const ItemPreview = (props) => {
         <div className="d-flex flex-row align-items-center pt-2">
           <Link to={`/@${item.seller.username}`} className="flex-grow-1">
             <img
-              src={item.seller.image}
+              src={item.seller.image || "/placeholder.png"}
               alt={item.seller.username}
               className="user-pic rounded-circle pr-1"
             />


### PR DESCRIPTION
# Description

Adding a placeholder when the item image is empty.

![Screenshot 2022-10-25 at 19 12 42](https://user-images.githubusercontent.com/3417854/197850585-89db1245-b1b1-4e82-92c2-8f4d0c9a44a0.png)
