### PR TITLE
fix(INC-5312): adding placeholder on image api

### DIFF
--- a/backend/app/db/repositories/items.py
+++ b/backend/app/db/repositories/items.py
@@ -309,7 +309,7 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
             title=title,
             description=item_row["description"],
             body=item_row["body"],
-            image=item_row["image"],
+            image=item_row["image"] or 'placeholder.png',
             seller=await self._profiles_repo.get_profile_by_username(
                 username=seller_username,
                 requested_user=requested_user,


### PR DESCRIPTION
# Description

Adding a placeholder  when the item image is empty on api.